### PR TITLE
sushi autostart fix for rpi4 8GB

### DIFF
--- a/autostart/tonalflex-autostart.service
+++ b/autostart/tonalflex-autostart.service
@@ -5,10 +5,13 @@ Wants=custom-elk.target
 
 [Service]
 Type=simple
+RemainAfterExit=yes
+LimitRTPRIO=infinity
+LimitMEMLOCK=infinity
+LimitSTACK=infinity
+WorkingDirectory=/home/mind
 ExecStart=/bin/bash /udata/autostart.sh
 User=mind
-Group=mind
-RemainAfterExit=yes
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
This PR fixes an issue where Sushi fails to apply plugin parameter changes when running on the 8GB Raspberry Pi 4 under Elk Audio OS.

Issue:
When starting Sushi via systemd/autostart, plugin parameters would remain at their default values and ignore set_parameter_value calls. This only occurred on the 8GB RPi4, while the 4GB RPi4 worked as expected.

Root Cause:
Due to the faster boot time on the 8GB model, the autostart script triggered slightly earlier in the boot process. As a result, Sushi was launched before the system had granted it real-time scheduling, defaulting to SCHED_OTHER with priority 0. This prevented certain VST3 plugins from responding correctly to parameter updates.